### PR TITLE
Add support for emitting `.luau` files

### DIFF
--- a/src/PathTranslator.ts
+++ b/src/PathTranslator.ts
@@ -189,8 +189,10 @@ export class PathTranslator {
 	}
 
 	/**
-	 * Maps a src path to an import path
-	 * - `.d.ts(x)` -> `.ts(x)` -> `.lua(u)`
+	 * Maps a src path to an import path.
+	 * Import paths are passed to RojoResolver and used virtually to resolve RbxPaths.
+	 * Because of this, the import path may not actually exist.
+	 * - `.d.ts(x)` -> `.ts(x)` -> `.luau`
 	 * 	- `index` -> `init`
 	 */
 	public getImportPath(filePath: string, isNodeModule = false) {
@@ -208,7 +210,7 @@ export class PathTranslator {
 				pathInfo.fileName = INIT_NAME;
 			}
 
-			pathInfo.exts.push(this.getLuauExt()); // push .lua(u)
+			pathInfo.exts.push(LUAU_EXT); // push .luau
 		}
 
 		// inside of node_modules, we assume compiled file is sibling of filePath

--- a/src/PathTranslator.ts
+++ b/src/PathTranslator.ts
@@ -66,7 +66,7 @@ export class PathTranslator {
 		const pathInfo = PathInfo.from(filePath);
 
 		if ((pathInfo.extsPeek() === TS_EXT || pathInfo.extsPeek() === TSX_EXT) && pathInfo.extsPeek(1) !== D_EXT) {
-			pathInfo.exts.pop(); // pop .tsx?
+			pathInfo.exts.pop(); // pop .ts(x)
 
 			// index -> init
 			if (pathInfo.fileName === INDEX_NAME) {
@@ -81,7 +81,7 @@ export class PathTranslator {
 
 	/**
 	 * Maps an input path to an output .d.ts path
-	 * - `.tsx?` && !`.d.tsx?` -> `.d.ts`
+	 * - `.ts(x)` && !`.d.ts(x)` -> `.d.ts`
 	 * - `src/*` -> `out/*`
 	 */
 	public getOutputDeclarationPath(filePath: string) {
@@ -89,7 +89,7 @@ export class PathTranslator {
 		const pathInfo = PathInfo.from(filePath);
 
 		if ((pathInfo.extsPeek() === TS_EXT || pathInfo.extsPeek() === TSX_EXT) && pathInfo.extsPeek(1) !== D_EXT) {
-			pathInfo.exts.pop(); // pop .tsx?
+			pathInfo.exts.pop(); // pop .ts(x)
 			pathInfo.exts.push(DTS_EXT);
 		}
 
@@ -97,8 +97,8 @@ export class PathTranslator {
 	}
 
 	/**
-	 * Maps an input path to an output .transformed.tsx? path
-	 * - `.tsx?` -> `.transformed.tsx?`
+	 * Maps an input path to an output .transformed.ts(x) path
+	 * - `.ts(x)` -> `.transformed.ts(x)`
 	 * - `src/*` -> `out/*`
 	 */
 	public getOutputTransformedPath(filePath: string) {
@@ -165,7 +165,7 @@ export class PathTranslator {
 
 		if (this.declaration) {
 			if ((pathInfo.extsPeek() === TS_EXT || pathInfo.extsPeek() === TSX_EXT) && pathInfo.extsPeek(1) === D_EXT) {
-				const tsExt = pathInfo.exts.pop(); // pop .tsx?
+				const tsExt = pathInfo.exts.pop(); // pop .ts(x)
 				assert(tsExt);
 				pathInfo.exts.pop(); // pop .d
 
@@ -198,7 +198,7 @@ export class PathTranslator {
 		const pathInfo = PathInfo.from(filePath);
 
 		if (pathInfo.extsPeek() === TS_EXT || pathInfo.extsPeek() === TSX_EXT) {
-			pathInfo.exts.pop(); // pop .tsx?
+			pathInfo.exts.pop(); // pop .ts(x)
 			if (pathInfo.extsPeek() === D_EXT) {
 				pathInfo.exts.pop(); // pop .d
 			}

--- a/src/PathTranslator.ts
+++ b/src/PathTranslator.ts
@@ -57,7 +57,7 @@ export class PathTranslator {
 
 	/**
 	 * Maps an input path to an output path
-	 * - `.ts(x)` && !`.d.ts(x)` -> `.luau`
+	 * - `.ts(x)` && !`.d.ts(x)` -> `.lua(u)`
 	 * 	- `index` -> `init`
 	 * - `src/*` -> `out/*`
 	 */
@@ -119,7 +119,7 @@ export class PathTranslator {
 
 	/**
 	 * Maps an output path to possible import paths
-	 * - `.luau` -> `.ts(x)`
+	 * - `.lua(u)` -> `.ts(x)`
 	 * 	- `init` -> `index`
 	 * - `out/*` -> `src/*`
 	 */
@@ -128,7 +128,7 @@ export class PathTranslator {
 		const possiblePaths = new Array<string>();
 		const pathInfo = PathInfo.from(filePath);
 
-		// index.*.luau cannot come from a .ts file
+		// index.*.lua(u) cannot come from a .ts file
 		if (pathInfo.extsPeek() === this.getLuauExt() && pathInfo.fileName !== INDEX_NAME) {
 			const originalExt = pathInfo.exts.pop();
 			assert(originalExt);
@@ -191,7 +191,7 @@ export class PathTranslator {
 
 	/**
 	 * Maps a src path to an import path
-	 * - `.d.ts(x)` -> `.ts(x)` -> `.luau`
+	 * - `.d.ts(x)` -> `.ts(x)` -> `.lua(u)`
 	 * 	- `index` -> `init`
 	 */
 	public getImportPath(filePath: string, isNodeModule = false) {
@@ -209,7 +209,7 @@ export class PathTranslator {
 				pathInfo.fileName = INIT_NAME;
 			}
 
-			pathInfo.exts.push(this.getLuauExt()); // push .luau
+			pathInfo.exts.push(this.getLuauExt()); // push .lua(u)
 		}
 
 		return isNodeModule ? pathInfo.join() : makeRelative(pathInfo);

--- a/src/PathTranslator.ts
+++ b/src/PathTranslator.ts
@@ -1,6 +1,16 @@
 import path from "path";
 
-import { D_EXT, DTS_EXT, INDEX_NAME, INIT_NAME, LUA_EXT, TRANSFORMED_EXT, TS_EXT, TSX_EXT } from "./constants";
+import {
+	D_EXT,
+	DTS_EXT,
+	INDEX_NAME,
+	INIT_NAME,
+	LUA_EXT,
+	LUAU_EXT,
+	TRANSFORMED_EXT,
+	TS_EXT,
+	TSX_EXT,
+} from "./constants";
 import { assert } from "./util/assert";
 
 class PathInfo {
@@ -34,6 +44,7 @@ export class PathTranslator {
 		public readonly outDir: string,
 		public readonly buildInfoOutputPath: string | undefined,
 		public readonly declaration: boolean,
+		public readonly useLuauExtension = false,
 	) {}
 
 	private makeRelativeFactory(from = this.rootDir, to = this.outDir) {
@@ -58,7 +69,7 @@ export class PathTranslator {
 				pathInfo.fileName = INIT_NAME;
 			}
 
-			pathInfo.exts.push(LUA_EXT);
+			pathInfo.exts.push(this.useLuauExtension ? LUAU_EXT : LUA_EXT);
 		}
 
 		return makeRelative(pathInfo);
@@ -114,8 +125,9 @@ export class PathTranslator {
 		const pathInfo = PathInfo.from(filePath);
 
 		// index.*.lua cannot come from a .ts file
-		if (pathInfo.extsPeek() === LUA_EXT && pathInfo.fileName !== INDEX_NAME) {
-			pathInfo.exts.pop();
+		if ((pathInfo.extsPeek() === LUAU_EXT || pathInfo.extsPeek() === LUA_EXT) && pathInfo.fileName !== INDEX_NAME) {
+			const originalExt = pathInfo.exts.pop();
+			assert(originalExt);
 
 			// ts
 			pathInfo.exts.push(TS_EXT);
@@ -145,7 +157,7 @@ export class PathTranslator {
 				pathInfo.fileName = originalFileName;
 			}
 
-			pathInfo.exts.push(LUA_EXT);
+			pathInfo.exts.push(originalExt);
 		}
 
 		if (this.declaration) {

--- a/src/PathTranslator.ts
+++ b/src/PathTranslator.ts
@@ -130,8 +130,7 @@ export class PathTranslator {
 
 		// index.*.lua(u) cannot come from a .ts file
 		if (pathInfo.extsPeek() === this.getLuauExt() && pathInfo.fileName !== INDEX_NAME) {
-			const originalExt = pathInfo.exts.pop();
-			assert(originalExt);
+			pathInfo.exts.pop(); // pop .lua(u)
 
 			// ts
 			pathInfo.exts.push(TS_EXT);
@@ -161,7 +160,7 @@ export class PathTranslator {
 				pathInfo.fileName = originalFileName;
 			}
 
-			pathInfo.exts.push(originalExt);
+			pathInfo.exts.push(this.getLuauExt());
 		}
 
 		if (this.declaration) {

--- a/src/PathTranslator.ts
+++ b/src/PathTranslator.ts
@@ -192,7 +192,7 @@ export class PathTranslator {
 	 * Maps a src path to an import path.
 	 * Import paths are passed to RojoResolver and used virtually to resolve RbxPaths.
 	 * Because of this, the import path may not actually exist.
-	 * - `.d.ts(x)` -> `.ts(x)` -> `.luau`
+	 * - `.d.ts(x)` -> `.ts(x)` -> `.lua(u)`
 	 * 	- `index` -> `init`
 	 */
 	public getImportPath(filePath: string, isNodeModule = false) {
@@ -210,7 +210,7 @@ export class PathTranslator {
 				pathInfo.fileName = INIT_NAME;
 			}
 
-			pathInfo.exts.push(LUAU_EXT); // push .luau
+			pathInfo.exts.push(this.getLuauExt()); // push .lua(u)
 		}
 
 		// inside of node_modules, we assume compiled file is sibling of filePath

--- a/src/PathTranslator.ts
+++ b/src/PathTranslator.ts
@@ -212,6 +212,8 @@ export class PathTranslator {
 			pathInfo.exts.push(this.getLuauExt()); // push .lua(u)
 		}
 
+		// inside of node_modules, we assume compiled file is sibling of filePath
+		// outside, we check relative to outDir
 		return isNodeModule ? pathInfo.join() : makeRelative(pathInfo);
 	}
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const D_EXT = ".d";
 export const DTS_EXT = D_EXT + TS_EXT;
 export const TRANSFORMED_EXT = ".transformed";
 export const LUA_EXT = ".lua";
+export const LUAU_EXT = ".luau";
 export const JSON_EXT = ".json";
 
 export const INDEX_NAME = "index";


### PR DESCRIPTION
Temporarily behind a flag because the compiler will have a `--luau` flag which defaults to true. Users will be able to do `--luau=false` if emitting `.luau` files breaks their workflows.

Fixes #1