### PR TITLE
Remove unused `JSON_EXT` constant

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,7 +4,6 @@ export const D_EXT = ".d";
 export const DTS_EXT = D_EXT + TS_EXT;
 export const TRANSFORMED_EXT = ".transformed";
 export const LUA_EXT = ".lua";
-export const JSON_EXT = ".json";
 
 export const INDEX_NAME = "index";
 export const INIT_NAME = "init";


### PR DESCRIPTION
Looks like this was in the initial commit, but not actually used in anywhere. Probably safe to remove.